### PR TITLE
Removed PySide==2 & opencmiss.zinc from requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ Topic :: Software Development :: Libraries :: Python Modules
 
 doc_lines = __doc__.split("\n")
 
-requires = ['opencmiss.utils >= 0.2.0', 'PySide2', 'opencmiss.zinc']
+requires = ['opencmiss.utils >= 0.2.0']
 
 setup(
     name='opencmiss.zincwidgets',


### PR DESCRIPTION
Currently having `PySide==2` and `opencmiss.zinc` in the `requires` filed cause issues in the installation. I propose to have these removed for now until the problem is addressed in MAPClient 2.

p.s. I am writing up an instruction document to install all the tools required for ScaffoldMaker as part of the SPARC Q1 Milestones. This fix should help speed up the installation process for the user.